### PR TITLE
sudo: update patch for missing MAP_ANON in mmap

### DIFF
--- a/packages/sudo/sudo.sgifixes.patch
+++ b/packages/sudo/sudo.sgifixes.patch
@@ -1,29 +1,60 @@
-diff -r -u -w sudo-1.8.24/lib/util/arc4random.h sudo-1.8.24-patched/lib/util/arc4random.h
---- sudo-1.8.24/lib/util/arc4random.h	2018-08-18 15:10:24.000000000 +0000
-+++ sudo-1.8.24-patched/lib/util/arc4random.h	2018-08-28 04:25:34.828550880 +0000
-@@ -85,11 +85,11 @@
+diff -r -u sudo-1.8.24/lib/util/arc4random.h sudo-1.8.24-ma/lib/util/arc4random.h
+--- sudo-1.8.24/lib/util/arc4random.h	2019-01-02 06:37:41.000000000 +0000
++++ sudo-1.8.24-ma/lib/util/arc4random.h	2019-10-07 22:58:12.360949996 +0000
+@@ -84,6 +84,21 @@
+ static inline int
  _rs_allocate(struct _rs **rsp, struct _rsx **rsxp)
  {
++#ifndef MAP_ANON
++	int fd;
++	if ((fd = open("/dev/zero", O_RDWR)) == -1)
++		return (-1);
++	if ((*rsp = (void *)mmap(NULL, sizeof(**rsp), PROT_READ|PROT_WRITE,
++	    MAP_PRIVATE, fd, 0)) == MAP_FAILED)
++		return (-1);
++
++	if ((*rsxp = (void *)mmap(NULL, sizeof(**rsxp), PROT_READ|PROT_WRITE,
++	    MAP_PRIVATE, fd, 0)) == MAP_FAILED) {
++		munmap((void *)*rsp, sizeof(**rsp));
++		*rsp = NULL;
++		return (-1);
++	}
++#else
  	if ((*rsp = (void *)mmap(NULL, sizeof(**rsp), PROT_READ|PROT_WRITE,
--	    MAP_ANON|MAP_PRIVATE, -1, 0)) == MAP_FAILED)
-+	    MAP_PRIVATE, -1, 0)) == MAP_FAILED)
+ 	    MAP_ANON|MAP_PRIVATE, -1, 0)) == MAP_FAILED)
  		return (-1);
- 
- 	if ((*rsxp = (void *)mmap(NULL, sizeof(**rsxp), PROT_READ|PROT_WRITE,
--	    MAP_ANON|MAP_PRIVATE, -1, 0)) == MAP_FAILED) {
-+	    MAP_PRIVATE, -1, 0)) == MAP_FAILED) {
- 		munmap((void *)*rsp, sizeof(**rsp));
+@@ -94,6 +109,7 @@
  		*rsp = NULL;
  		return (-1);
-diff -r -u -w sudo-1.8.24/lib/util/getentropy.c sudo-1.8.24-patched/lib/util/getentropy.c
---- sudo-1.8.24/lib/util/getentropy.c	2018-08-18 15:10:24.000000000 +0000
-+++ sudo-1.8.24-patched/lib/util/getentropy.c	2018-08-28 04:25:44.596618320 +0000
-@@ -463,7 +463,7 @@
+ 	}
++#endif
+ 
+ #ifdef MADV_WIPEONFORK
+ 	if (madvise (*rsp, sizeof(**rsp), MADV_WIPEONFORK) == 0 &&
+diff -r -u sudo-1.8.24/lib/util/getentropy.c sudo-1.8.24-ma/lib/util/getentropy.c
+--- sudo-1.8.24/lib/util/getentropy.c	2019-01-02 06:37:41.000000000 +0000
++++ sudo-1.8.24-ma/lib/util/getentropy.c	2019-10-07 22:39:47.182890691 +0000
+@@ -468,11 +468,23 @@
+ 				};
+ 
+ 				for (m = 0; m < sizeof mm/sizeof(mm[0]); m++) {
++#ifndef MAP_ANON
++					int fd;
++					if ((fd = open("/dev/zero", O_RDWR)) == -1)
++						mm[m].p = MAP_FAILED;
++					HX(mm[m].p = mmap(NULL,
++					    mm[m].npg * pgs,
++					    PROT_READ|PROT_WRITE,
++					    MAP_PRIVATE, fd,
++					    (off_t)0), mm[m].p);
++#else
  					HX(mm[m].p = mmap(NULL,
  					    mm[m].npg * pgs,
  					    PROT_READ|PROT_WRITE,
--					    MAP_PRIVATE|MAP_ANON, -1,
-+					    MAP_PRIVATE, -1,
+ 					    MAP_PRIVATE|MAP_ANON, -1,
  					    (off_t)0), mm[m].p);
++#endif
++
  					if (mm[m].p != MAP_FAILED) {
  						size_t mo;
+ 


### PR DESCRIPTION
I made this patch for 1.8.27 based on tips in the discord related to another port that had the same undefined MAP_ANON issue and adapting an existing `#ifndef MAP_ANON` block was already in the lib/util/snprintf.c file.

I am unable to test building within didbs but compiling separately using didbs gcc9 passed almost all tests except for check_timestamps.